### PR TITLE
fix: when click token detail filter the token with contract id

### DIFF
--- a/components/Activity/ActivityDetail.js
+++ b/components/Activity/ActivityDetail.js
@@ -420,17 +420,13 @@ const ActivityDetail = ({ activity }) => {
 								<Link
 									href={{
 										pathname: router.pathname,
-										query: activity.token_id
-											? {
-													...router.query,
-													...{ tokenId: localToken?.token_id },
-													...{ prevAs: router.asPath },
-											  }
-											: {
-													...router.query,
-													...{ tokenSeriesId: localToken?.token_series_id },
-													...{ prevAs: router.asPath },
-											  },
+										query: {
+											...router.query,
+											...(activity.token_id
+												? { tokenId: localToken?.token_id }
+												: { tokenSeriesId: localToken?.token_series_id }),
+											contractId: localToken?.contract_id,
+										},
 									}}
 									as={`/token/${localToken?.contract_id}::${localToken?.token_series_id}${
 										activity.token_id ? `/${localToken?.token_id}` : ''

--- a/components/Activity/CollectionTransactionDetail.js
+++ b/components/Activity/CollectionTransactionDetail.js
@@ -159,8 +159,8 @@ const UserTransactionCard = ({ contract_token_id, setLocalToken }) => {
 								pathname: router.pathname,
 								query: {
 									...router.query,
-									...{ tokenId: token.token_id },
-									...{ prevAs: router.asPath },
+									tokenId: token.token_id,
+									contractId: token.contract_id,
 								},
 							},
 							`/token/${token.contract_id}::${token.token_series_id}/${token.token_id}`,

--- a/components/Activity/UserTransactionDetail.js
+++ b/components/Activity/UserTransactionDetail.js
@@ -161,8 +161,8 @@ const UserTransactionCard = ({ contract_token_id, setLocalToken }) => {
 								pathname: router.pathname,
 								query: {
 									...router.query,
-									...{ tokenId: token.token_id },
-									...{ prevAs: router.asPath },
+									tokenId: token.token_id,
+									contractId: token.contract_id,
 								},
 							},
 							`/token/${token.contract_id}::${token.token_series_id}/${token.token_id}`,

--- a/components/Bid/Bid.js
+++ b/components/Bid/Bid.js
@@ -233,9 +233,9 @@ const Bid = ({ data, type }) => {
 										pathname: router.pathname,
 										query: {
 											...router.query,
-											...{ tokenSeriesId: token.token_series_id },
-											...{ tokenId: token.token_id },
-											...{ prevAs: router.asPath },
+											tokenSeriesId: token.token_series_id,
+											tokenId: token.token_id,
+											contractId: token.contract_id,
 										},
 									},
 									token.token_id
@@ -263,9 +263,9 @@ const Bid = ({ data, type }) => {
 									pathname: router.pathname,
 									query: {
 										...router.query,
-										...{ tokenSeriesId: token.token_series_id },
-										...{ tokenId: token.token_id },
-										...{ prevAs: router.asPath },
+										tokenSeriesId: token.token_series_id,
+										tokenId: token.token_id,
+										contractId: token.contract_id,
 									},
 								}}
 								as={

--- a/components/Publication/EmbeddedCard.js
+++ b/components/Publication/EmbeddedCard.js
@@ -68,8 +68,8 @@ const EmbeddedCard = ({ tokenId }) => {
 										pathname: router.pathname,
 										query: {
 											...router.query,
-											...{ tokenSeriesId: token.token_series_id },
-											...{ prevAs: router.asPath },
+											tokenSeriesId: token.token_series_id,
+											contractId: token.contract_id,
 										},
 									},
 									`/token/${token.contract_id}::${token.token_series_id}`,

--- a/components/Stats/CardStats.js
+++ b/components/Stats/CardStats.js
@@ -19,8 +19,8 @@ const CardStats = ({ cardsData, fetchData, hasMore }) => {
 				pathname: router.pathname,
 				query: {
 					...router.query,
-					...{ tokenId: localToken?.tokenId },
-					...{ prevAs: router.asPath },
+					tokenId: localToken?.token_id,
+					contractId: localToken?.contract_id,
 				},
 			},
 			`/token/${localToken?.tokenId}`,

--- a/components/Token/TokenDetailModal.js
+++ b/components/Token/TokenDetailModal.js
@@ -28,7 +28,10 @@ function TokenDetailModal({ tokens = [] }) {
 
 	useEffect(() => {
 		if (router.query.tokenId && activeToken === null) {
-			const token = tokens.find((token) => token?.token_id === router.query.tokenId)
+			const token = tokens.find(
+				(token) =>
+					token?.token_id === router.query.tokenId && token?.contract_id === router.query.contractId
+			)
 			setActiveToken(token)
 		} else {
 			setActiveToken(null)

--- a/components/Token/TokenList.js
+++ b/components/Token/TokenList.js
@@ -64,8 +64,8 @@ const TokenList = ({ name = 'default', tokens, fetchData, hasMore }) => {
 				pathname: router.pathname,
 				query: {
 					...router.query,
-					...{ tokenId: token.token_id },
-					...{ prevAs: router.asPath },
+					tokenId: token.token_id,
+					contractId: token.contract_id,
 				},
 			},
 			`/token/${token.contract_id}::${token.token_series_id}/${token.token_id}`,

--- a/components/TokenSeries/CardList.js
+++ b/components/TokenSeries/CardList.js
@@ -65,8 +65,8 @@ const CardList = ({ name = 'default', tokens, fetchData, hasMore }) => {
 				pathname: router.pathname,
 				query: {
 					...router.query,
-					...{ tokenSeriesId: token.token_series_id },
-					...{ prevAs: router.asPath },
+					tokenSeriesId: token.token_series_id,
+					contractId: token.contract_id,
 				},
 			},
 			`/token/${token.contract_id}::${token.token_series_id}`,

--- a/components/TokenSeries/TokenSeriesDetailModal.js
+++ b/components/TokenSeries/TokenSeriesDetailModal.js
@@ -28,7 +28,11 @@ function TokenSeriesDetailModal({ tokens = [] }) {
 
 	useEffect(() => {
 		if (router.query.tokenSeriesId && activeToken === null) {
-			const token = tokens.find((token) => token?.token_series_id === router.query.tokenSeriesId)
+			const token = tokens.find(
+				(token) =>
+					token?.token_series_id === router.query.tokenSeriesId &&
+					token?.contract_id === router.query.contractId
+			)
 			setActiveToken(token)
 		} else {
 			setActiveToken(null)

--- a/pages/category-submission/[categoryId].js
+++ b/pages/category-submission/[categoryId].js
@@ -236,8 +236,8 @@ const SubmissionDetail = ({ submission, updateData }) => {
 								pathname: router.pathname,
 								query: {
 									...router.query,
-									...{ tokenSeriesId: localToken?.token_series_id },
-									...{ prevAs: router.asPath },
+									tokenSeriesId: localToken?.token_series_id,
+									contractId: localToken?.contract_id,
 								},
 							}}
 							as={`/token/${localToken?.contract_id}::${localToken?.token_series_id}`}

--- a/pages/drops.js
+++ b/pages/drops.js
@@ -331,8 +331,8 @@ const SpecialCard = ({
 					pathname: router.pathname,
 					query: {
 						...router.query,
-						...{ tokenSeriesId: localToken.token_series_id },
-						...{ prevAs: router.asPath },
+						tokenSeriesId: localToken.token_series_id,
+						contractId: localToken.contract_id,
 					},
 				},
 				`/token/${localToken.contract_id}::${localToken.token_series_id}`,


### PR DESCRIPTION
### Changes
[x] filter with contract id when clicking token detail
[x] refactor `router.push` to token series and token detail