### PR TITLE
feat: add no index meta when the env is not production

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -16,6 +16,12 @@ class MyDocument extends Document {
 			<Html>
 				<Head>
 					<Fragment>
+						{process.env.APP_ENV !== 'production' && (
+							<>
+								<meta name="robots" content="noindex" />
+								<meta name="googlebot" content="noindex" />
+							</>
+						)}
 						{/* Global Site Tag (gtag.js) - Google Analytics */}
 						<script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
 						<script


### PR DESCRIPTION
https://developers.google.com/search/docs/advanced/crawling/block-indexing