### PR TITLE
fix: hide button offer for token in auction

### DIFF
--- a/components/Token/TokenDetail.js
+++ b/components/Token/TokenDetail.js
@@ -873,7 +873,7 @@ const TokenDetail = ({ token, className, isAuctionEnds }) => {
 								</Button>
 							</div>
 						)}
-						{token.owner_id !== currentUser && !token.price && (
+						{token.owner_id !== currentUser && !token.price && !token.is_auction && (
 							<Button size="md" onClick={onClickOffer} isFullWidth variant="secondary">
 								{hasBid ? `Update Offer` : `Make Offer`}
 							</Button>


### PR DESCRIPTION
## Cause
Make the offer button shows in token detail modal with is_auction 
example : https://paras.id/market?sort=urgentAuction&is_verified=true&card_trade_type=onAuction
